### PR TITLE
include MANIFEST.in in sdist

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,1 @@
-include README.rst LICENSE certifi/cacert.pem
+include MANIFEST.in README.rst LICENSE certifi/cacert.pem


### PR DESCRIPTION
This change will include MANIFEST.in with the source dist that gets uploaded to pypi:

```
% python setup.py sdist
[...]
% tar tvzf dist/certifi-0.0.8.tar.gz | grep MANIFEST.in
-rw-r--r-- petef/petef      58 2012-04-09 11:38 certifi-0.0.8/MANIFEST.in
```

This change will enable (pypi2rpm)[http://pypi.python.org/pypi/pypi2rpm] to properly build an RPM from the pypi source.
