### PR TITLE
Add __version__

### DIFF
--- a/certifi/__init__.py
+++ b/certifi/__init__.py
@@ -1,1 +1,3 @@
 from .core import where
+
+__version__ = "14.05.14"


### PR DESCRIPTION
Added \__version__ attr to package so that scripts that check local
packages to see if newer versions are available can work.

Almost all Python packages have a version attr, and the vast majority of
them name it "\__version__"