### PR TITLE
Publish with wheel

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,4 @@ update:
 	curl http://ci.kennethreitz.org/job/ca-bundle/lastSuccessfulBuild/artifact/cacerts.pem -o certifi/cacert.pem
 
 publish:
-	python setup.py register
-	python setup.py sdist upload
-	python setup.py bdist_wheel upload
+	python setup.py publish

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ from setuptools import setup
 VERSION = '14.05.14'
 
 if sys.argv[-1] == 'publish':
-    os.system('python setup.py sdist upload')
+    os.system('python setup.py sdist bdist_wheel upload')
     sys.exit()
 
 required = []


### PR DESCRIPTION
As the `Makefile` contains `bdist_wheel`, I presume that "python setup.py publish" is used to make releases (because there is no wheel on PyPI for this version). This ensures that, regardless of which command is used to make a release, a wheel is available to download.