### PR TITLE
Use OS X trust store when availalble

### DIFF
--- a/certifi/core.py
+++ b/certifi/core.py
@@ -10,6 +10,8 @@ This module returns the installation location of cacert.pem.
 import os
 import warnings
 
+from . import system
+
 
 class DeprecatedBundleWarning(DeprecationWarning):
     """
@@ -19,9 +21,7 @@ class DeprecatedBundleWarning(DeprecationWarning):
 
 
 def where():
-    f = os.path.split(__file__)[0]
-
-    return os.path.join(f, 'cacert.pem')
+    return system.WHERE
 
 
 def old_where():

--- a/certifi/system/__init__.py
+++ b/certifi/system/__init__.py
@@ -1,0 +1,35 @@
+import os as _os
+from os import path as _path
+import sys as _sys
+
+
+if _sys.platform == 'darwin':
+    from . import osx
+    OS_TRUSTED_CERTS = osx.OS_TRUSTED_CERTS
+    CA_BUNDLE = osx.USER_CA_BUNDLE
+else:
+    # Unsupported platform for this feature
+    OS_TRUSTED_CERTS = ''
+    CA_BUNDLE = None
+
+
+def _regenerate_where():
+    certifi_pem = _path.abspath(_path.join(_path.split(__file__)[0], '..', 'cacert.pem'))
+    if not CA_BUNDLE:
+        return certifi_pem
+    elif OS_TRUSTED_CERTS:
+        if not _path.exists(_path.dirname(CA_BUNDLE)):
+            _os.makedirs(_path.dirname(CA_BUNDLE))
+        with open(CA_BUNDLE, 'wb') as user_bundle:
+            with open(certifi_pem, 'rb') as built_in_pem:
+                certifi_certs = built_in_pem.read()
+            user_bundle.write(certifi_certs + '\n' + OS_TRUSTED_CERTS)
+        return CA_BUNDLE
+    else:
+        return CA_BUNDLE
+
+
+WHERE = _regenerate_where()
+
+
+__all__ = ('WHERE',)

--- a/certifi/system/osx.py
+++ b/certifi/system/osx.py
@@ -1,0 +1,33 @@
+import os
+import subprocess
+
+
+SYSTEM_KEYCHAIN = '/Library/Keychains/System.keychain'
+SYSTEM_CA_KEYCHAIN = '/System/Library/Keychains/SystemRootCertificates.keychain'
+USER_CA_BUNDLE = os.path.expanduser('~/Library/Caches/certifi/OS-bundle.pem')
+
+
+def mtime_or_never(filename):
+    try:
+        mtime = os.stat(filename).st_mtime
+        return mtime
+    except OSError:
+        return float('-inf')
+
+
+def try_security():
+    try:
+        return subprocess.check_output(['security', 'find-certificate', '-a', '-p'])
+    except subprocess.CalledProcessError:
+        # Assume that nothing is wrong and set this to blank
+        return ''
+
+
+if not os.path.exists(USER_CA_BUNDLE):
+    OS_TRUSTED_CERTS = try_security()
+else:
+    max_time = max(mtime_or_never(SYSTEM_KEYCHAIN), mtime_or_never(SYSTEM_CA_KEYCHAIN))
+    if max_time > mtime_or_never(USER_CA_BUNDLE):
+        OS_TRUSTED_CERTS = try_security()
+    else:
+        OS_TRUSTED_CERTS = ''


### PR DESCRIPTION
This commit is in response to #25. We would dearly like this feature for our own setup, so we decided to implement it.

I think that this is the setup described in #25, but I would be more than happy to fix it up if I've misinterpreted or beliefs have changed..

Notably, we did run into an interesting conundrum while testing. Specifically, when we used the default system version of python, requests seemed to succeed *without* this patch, but the brew version of python did not. If somebody else wants to test this out with various versions of python and requests (both the system and non system versions) that would be awesome.