### PR TITLE
Fix Python 2.5's lack of a builtin with statement

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+from __future__ import with_statement
 import re
 import os
 import sys


### PR DESCRIPTION
The with statement was added in 2.6 but available in `__future__`
in 2.5. This fixes #38 as reported.