### PR TITLE
Use `distutils` if `setuptools` is missing

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,6 +5,12 @@ import re
 import os
 import sys
 
+# While I generally consider it an antipattern to try and support both
+# setuptools and distutils with a single setup.py, in this specific instance
+# where packaging is a dependency of setuptools, it can create a circular
+# dependency when projects attempt to unbundle stuff from setuptools and pip.
+# Though we don't really support that, it makes things easier if we do this and
+# should hopefully cause less issues for end users.
 try:
     from setuptools import setup
 except ImportError:

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,11 @@ import re
 import os
 import sys
 
-from setuptools import setup
+try:
+    from setuptools import setup
+except ImportError:
+    from distutils.core import setup
+
 
 version_regex = r'__version__ = ["\']([^"\']*)["\']'
 with open('certifi/__init__.py', 'r') as f:

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ import sys
 
 # While I generally consider it an antipattern to try and support both
 # setuptools and distutils with a single setup.py, in this specific instance
-# where packaging is a dependency of setuptools, it can create a circular
+# where certifi is a dependency of setuptools, it can create a circular
 # dependency when projects attempt to unbundle stuff from setuptools and pip.
 # Though we don't really support that, it makes things easier if we do this and
 # should hopefully cause less issues for end users.


### PR DESCRIPTION
Fixes https://github.com/certifi/python-certifi/issues/42

This is needed in some cases where `setuptools` and `certifi` are being packaged. In those cases, a circular dependency appears. A simple way to break it is to make `certifi` only use `setuptools` if present. When `setuptools` is not found, it uses `distutils` to break the circular dependency.

cc @alex @dstufft