### PR TITLE
Change license from ISC to MPL-2.0 in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ setup(
     package_data={'certifi': ['*.pem']},
     # data_files=[('certifi', ['certifi/cacert.pem'])],
     include_package_data=True,
-    license='ISC',
+    license='MPL-2.0',
     classifiers=(
         'Development Status :: 5 - Production/Stable',
         'Intended Audience :: Developers',


### PR DESCRIPTION
Currently, `pip show certifi` will tell you that this package uses `ISC` as its license when in fact the `LICENSE` file says it is `MPL-2.0`. PR changes `ISC` -> `MPL-2.0`