### PR TITLE
set zip_safe=False to help out setuptools

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -47,6 +47,7 @@ setup(
     package_data={'certifi': ['*.pem']},
     # data_files=[('certifi', ['certifi/cacert.pem'])],
     include_package_data=True,
+    zip_safe=False,
     license='MPL-2.0',
     classifiers=(
         'Development Status :: 5 - Production/Stable',


### PR DESCRIPTION
There seems to be an issue in setuptools with it identifying the zip_safe-ness of the package when building an egg. This should be corrected in setuptools, however seeing as we know that the egg is not zip_safe (for the same reason setuptools should identify it as such, as it is referencing `__file__`) add the `zip_safe` flag to setup.