### PR TITLE
Update version to match pypi

### DIFF
--- a/certifi/__init__.py
+++ b/certifi/__init__.py
@@ -1,3 +1,3 @@
 from .core import where, old_where
 
-__version__ = "2017.04.17"
+__version__ = "2017.4.17"


### PR DESCRIPTION
The version in pypi is 2017.4.17, however setup.py defines version as 2017.04.17
This can cause problems with downstream systems that process setup.py to generate
rpms and debs