### PR TITLE
Solved import error on windows

### DIFF
--- a/certifi/__init__.py
+++ b/certifi/__init__.py
@@ -1,3 +1,3 @@
-from .core import where, old_where
+from core import where, old_where
 
 __version__ = "2018.04.16"


### PR DESCRIPTION
Hi,
i'm installed your package on a windows 10 x64 machine with python 2.7 with pip and after from the master branch and both give me that error:
```PS C:\Users\Andrea\Desktop> python.exe
Python 2.7.14 (v2.7.14:84471935ed, Sep 16 2017, 20:25:58) [MSC v.1500 64 bit (AMD64)] on win32
Type "help", "copyright", "credits" or "license" for more information.
>>> import certifi
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "C:\Python27\lib\site-packages\certifi\__init__.py", line 1, in <module>
    from .core import where, old_where
ImportError: cannot import name where
>>>
```

I fixed the error changing `from .core import where, old_where
` to `from core import where, old_where
` in __init__.