### PR TITLE
Add Python 3.7 trove classifier

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -63,5 +63,6 @@ setup(
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
     ],
 )


### PR DESCRIPTION
Python 3.7 was released on June 27, 2018.

https://docs.python.org/3/whatsnew/3.7.html