### PR TITLE
Remove shebang and standalone behavior from certifi/core.py

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -23,6 +23,11 @@ built-in function::
     >>> certifi.where()
     '/usr/local/lib/python2.7/site-packages/certifi/cacert.pem'
 
+Or from the command line::
+
+    $ python -m certifi
+    /usr/local/lib/python2.7/site-packages/certifi/cacert.pem
+
 Enjoy!
 
 1024-bit Root Certificates

--- a/certifi/core.py
+++ b/certifi/core.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 """
@@ -14,7 +13,3 @@ def where():
     f = os.path.dirname(__file__)
 
     return os.path.join(f, 'cacert.pem')
-
-
-if __name__ == '__main__':
-    print(where())


### PR DESCRIPTION
The file `certifi/core.py` is not intended as a command line entry point for certifi. Instead one can use:

    $ python -m certifi
    /usr/local/lib/python2.7/site-packages/certifi/cacert.pem

This use is now documented.

Further, the file isn't set as executable, so the shebang is pointless.