### PR TITLE
Possibility to override the CA bundle location

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -28,6 +28,17 @@ Or from the command line::
     $ python -m certifi
     /usr/local/lib/python2.7/site-packages/certifi/cacert.pem
 
+Or when using modules relying certifi and using a custom CA bundle (eg. including internal authority)::
+
+    >>> import certifi
+    >>> import os
+
+    >>> os.environ.get('CERTIFI_CA_BUNDLE')
+    '/etc/ssl/certs/ca-certificates.crt'
+    >>> certifi.where()
+    '/etc/ssl/certs/ca-certificates.crt'
+
+
 Enjoy!
 
 1024-bit Root Certificates

--- a/certifi/core.py
+++ b/certifi/core.py
@@ -10,6 +10,11 @@ import os
 
 
 def where():
+
+    # Overrides CA bundle location with custom value
+    if os.environ.get('CERTIFI_CA_BUNDLE'):
+        return os.environ.get('CERTIFI_CA_BUNDLE')
+
     f = os.path.dirname(__file__)
 
     return os.path.join(f, 'cacert.pem')


### PR DESCRIPTION
Like Request module, the aim is to be able to override the CA bundle location using an environment variable CERTIFI_CA_BUNDLE.

This is usefull when using a python module relying on certifi and when you have an internal authority (not included in the official bundle)