### PR TITLE
Add LICENSE metadata to bundled Python package

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -48,6 +48,7 @@ setup(
     include_package_data=True,
     zip_safe=False,
     license='MPL-2.0',
+    license_files=['LICENSE'],
     classifiers=[
         'Development Status :: 5 - Production/Stable',
         'Intended Audience :: Developers',


### PR DESCRIPTION
Currently [pip-licenses](https://github.com/raimon49/pip-licenses) can't include the LICENSE file for this project because the correct metadata is not setup.

This PR sets up the metadata correctly so the LICENSE file is properly included/linked to in source and wheel distributions.