### PR TITLE
allow PYTHON_CERTIFI_WHERE to override stock cert location

### DIFF
--- a/certifi/core.py
+++ b/certifi/core.py
@@ -10,6 +10,10 @@ import os
 
 
 def where():
+
+    if 'PYTHON_CERTIFI_WHERE' in os.environ:
+        return os.environ['PYTHON_CERTIFI_WHERE']
+
     f = os.path.dirname(__file__)
 
     return os.path.join(f, 'cacert.pem')


### PR DESCRIPTION
Many systems have stock locations for storing custom TLS Certificate Authority certificates which are shared by the default configuration of many applications.  For example, on Fedora systems, the default CA database is /etc/pki/tls/cert.pem.

To customize certifi to use such a database is currently painful, requiring for eample the  editing of files within the site_packages of a virtual environment, a painful procedure in containerized environments.

This PR proposes a simple solution which allows a custom cacert location to be defined by the PYTHON_CERTIFI_WHERE environment variable.

