### PR TITLE
Add a "contents" function that returns the content of the cert chain.

### DIFF
--- a/certifi/__init__.py
+++ b/certifi/__init__.py
@@ -1,3 +1,3 @@
-from .core import where
+from .core import what, where
 
 __version__ = "2019.11.28"

--- a/certifi/__init__.py
+++ b/certifi/__init__.py
@@ -1,3 +1,3 @@
-from .core import what, where
+from .core import contents, where
 
 __version__ = "2019.11.28"

--- a/certifi/__main__.py
+++ b/certifi/__main__.py
@@ -1,2 +1,12 @@
-from certifi import where
-print(where())
+import argparse
+
+from certifi import what, where
+
+parser = argparse.ArgumentParser()
+parser.add_argument("-w", "--what", action="store_true")
+args = parser.parse_args()
+
+if args.what:
+    print(what())
+else:
+    print(where())

--- a/certifi/__main__.py
+++ b/certifi/__main__.py
@@ -1,12 +1,12 @@
 import argparse
 
-from certifi import what, where
+from certifi import contents, where
 
 parser = argparse.ArgumentParser()
-parser.add_argument("-w", "--what", action="store_true")
+parser.add_argument("-c", "--contents", action="store_true")
 args = parser.parse_args()
 
-if args.what:
-    print(what())
+if args.contents:
+    print(contents())
 else:
     print(where())

--- a/certifi/core.py
+++ b/certifi/core.py
@@ -16,7 +16,8 @@ except ImportError:
     # so won't address issues with environments like PyOxidizer that don't set
     # __file__ on modules.
     def read_text(_module, _path, encoding="ascii"):
-        return open(where(), "r", encoding=encoding).read()
+        with open(where(), "r", encoding=encoding) as data:
+            return data.read()
 
 
 def where():

--- a/certifi/core.py
+++ b/certifi/core.py
@@ -6,6 +6,7 @@ certifi.py
 
 This module returns the installation location of cacert.pem.
 """
+import importlib.resources
 import os
 
 
@@ -13,3 +14,8 @@ def where():
     f = os.path.dirname(__file__)
 
     return os.path.join(f, 'cacert.pem')
+
+
+def what():
+    with importlib.resources.open_binary("certifi", "cacert.pem") as fh:
+        return fh.read()

--- a/certifi/core.py
+++ b/certifi/core.py
@@ -17,4 +17,4 @@ def where():
 
 
 def what():
-    return importlib.resources.read_text("certifi", "cacert.pem")
+    return importlib.resources.read_text("certifi", "cacert.pem", encoding="ascii")

--- a/certifi/core.py
+++ b/certifi/core.py
@@ -22,7 +22,7 @@ except ImportError:
 def where():
     f = os.path.dirname(__file__)
 
-    return os.path.join(f, 'cacert.pem')
+    return os.path.join(f, "cacert.pem")
 
 
 def contents():

--- a/certifi/core.py
+++ b/certifi/core.py
@@ -4,7 +4,7 @@
 certifi.py
 ~~~~~~~~~~
 
-This module returns the installation location of cacert.pem.
+This module returns the installation location of cacert.pem or its contents.
 """
 import os
 

--- a/certifi/core.py
+++ b/certifi/core.py
@@ -6,8 +6,13 @@ certifi.py
 
 This module returns the installation location of cacert.pem.
 """
-import importlib.resources
 import os
+
+try:
+    from importlib.resources import read_text
+except ImportError:
+    def read_text(_module, _path, encoding="ascii"):
+        return open(where(), "r", encoding=encoding).read()
 
 
 def where():
@@ -17,4 +22,4 @@ def where():
 
 
 def what():
-    return importlib.resources.read_text("certifi", "cacert.pem", encoding="ascii")
+    return read_text("certifi", "cacert.pem", encoding="ascii")

--- a/certifi/core.py
+++ b/certifi/core.py
@@ -11,6 +11,10 @@ import os
 try:
     from importlib.resources import read_text
 except ImportError:
+    # This fallback will work for Python versions prior to 3.7 that lack the
+    # importlib.resources module but relies on the existing `where` function
+    # so won't address issues with environments like PyOxidizer that don't set
+    # __file__ on modules.
     def read_text(_module, _path, encoding="ascii"):
         return open(where(), "r", encoding=encoding).read()
 

--- a/certifi/core.py
+++ b/certifi/core.py
@@ -21,5 +21,5 @@ def where():
     return os.path.join(f, 'cacert.pem')
 
 
-def what():
+def contents():
     return read_text("certifi", "cacert.pem", encoding="ascii")

--- a/certifi/core.py
+++ b/certifi/core.py
@@ -17,5 +17,4 @@ def where():
 
 
 def what():
-    with importlib.resources.open_binary("certifi", "cacert.pem") as fh:
-        return fh.read()
+    return importlib.resources.read_text("certifi", "cacert.pem")


### PR DESCRIPTION
Currently requests cannot be used in things like PyOxidizer due to a reliance on the `__file__` attribute. This change allows direct access to the PEM data in the cacert.pem file which can eventually be plumbed into the lower mechanisms of requests and urllib3 in order to allow these to work.