### PR TITLE
Use resources loader to handle non-filesystem situations

### DIFF
--- a/certifi/core.py
+++ b/certifi/core.py
@@ -24,17 +24,6 @@ try:
 except ImportError:
     _HAVE_PKG_RESOURCES = False
 
-try:
-    from importlib.resources import read_text
-except ImportError:
-    # This fallback will work for Python versions prior to 3.7 that lack the
-    # importlib.resources module but relies on the existing `where` function
-    # so won't address issues with environments like PyOxidizer that don't set
-    # __file__ on modules.
-    def read_text(_module, _path, encoding="ascii"):
-        with open(where(), "r", encoding=encoding) as data:
-            return data.read()
-
 _PACKAGE_NAME = "certifi"
 _CACERT_NAME = "cacert.pem"
 
@@ -52,4 +41,5 @@ def contents():
     if _HAVE_RESOURCE_READER:
         return importlib.resources.read_text(_PACKAGE_NAME, _CACERT_NAME, encoding="ascii")
     else:
-        return read_text(_PACKAGE_NAME, _CACERT_NAME, encoding="ascii")
+        with open(where(), "r", encoding="ascii") as data:
+            return data.read()

--- a/certifi/core.py
+++ b/certifi/core.py
@@ -6,7 +6,23 @@ certifi.py
 
 This module returns the installation location of cacert.pem or its contents.
 """
+import importlib
 import os
+
+try:
+    import importlib.resources
+    # Defeat lazy module importers.
+    importlib.resources.open_binary
+    _HAVE_RESOURCE_READER = True
+except ImportError:
+    _HAVE_RESOURCE_READER = False
+
+try:
+    import pkg_resources
+    # Defeat lazy module importers.
+    _HAVE_PKG_RESOURCES = True
+except ImportError:
+    _HAVE_PKG_RESOURCES = False
 
 try:
     from importlib.resources import read_text
@@ -19,12 +35,21 @@ except ImportError:
         with open(where(), "r", encoding=encoding) as data:
             return data.read()
 
+_PACKAGE_NAME = "certifi"
+_CACERT_NAME = "cacert.pem"
+
 
 def where():
-    f = os.path.dirname(__file__)
-
-    return os.path.join(f, "cacert.pem")
+    if _HAVE_PKG_RESOURCES:
+        return pkg_resources.resource_filename(_PACKAGE_NAME, _CACERT_NAME)
+    else:
+        mod = importlib.import_module(_PACKAGE_NAME)
+        path = os.path.dirname(mod.__file__)
+        return os.path.join(path, _CACERT_NAME)
 
 
 def contents():
-    return read_text("certifi", "cacert.pem", encoding="ascii")
+    if _HAVE_RESOURCE_READER:
+        return importlib.resources.read_text(_PACKAGE_NAME, _CACERT_NAME, encoding="ascii")
+    else:
+        return read_text(_PACKAGE_NAME, _CACERT_NAME, encoding="ascii")


### PR DESCRIPTION
While playing around with [PyOxidizer](https://pyoxidizer.readthedocs.io/), I realized that `certifi` was not working properly in self-contained executables generated by this tool. The typical traceback is the following:
```
Traceback (most recent call last):
  File ...  # Some code that relies on requests library
  File "requests", line 112, in <module>
  File "requests.utils", line 39, in <module>
  File "certifi.core", line 13, in where
NameError: name '__file__' is not defined
```

PyOxidizer maintainers made a complete explanation in this page of what is going on: https://pyoxidizer.readthedocs.io/en/stable/packaging_pitfalls.html. Short answer is: one cannot rely on `__file__` existence. Indeed the module may be exposed to Python runtime through an archive file, or even no file at all and directly from the RAM. In these cases `__file__` is irrelevant or does not exist.

However, the `certifi.core.where()` method is built on the assumption that `__file__` exists and can be used to get the actual path of `cacert.pem`.

In the same page about the Packaging Pitfalls (https://pyoxidizer.readthedocs.io/en/stable/packaging_pitfalls.html), PyOxidizer maintainers provide some decent alternatives to `__file__` in order to handle these situations, and these alternatives are using high level resources loaders APIs that have been added progressively to Python.

Functional examples are provided, and I used them to reimplement the `certifi.core` module, in order to consume the available resource loaders if possible. Thanks to it, in non-filesystem situations:
* `where()` will extract the file content if `pkg_resources` is available and put it as a temporary file in the current Python cache, then return its path.
* `contents()` will directly return the file content if `importlib.resources` is available (and so handling the path manipulations internally), or rely on `where()` to return this content.

As a general fallback, if no resources loader is available, the original behavior of `certifi.core` will be triggered: relying on `__file__` existence. This fallback may happen on Python <3.7, and never on Python 3.7+, making `certifi` (and so `requests`) work in any situation with this recent version of Python.

Fixes #66