### PR TITLE
Fix syntax error in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -65,7 +65,7 @@ setup(
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8'
     ],
-    project_urls: {
+    project_urls={
         'Documentation': 'https://certifiio.readthedocs.io/en/latest/',
         'Source': 'https://github.com/certifi/python-certifi',
     },


### PR DESCRIPTION
Fixes issue reported at https://github.com/certifi/python-certifi/pull/119#issuecomment-602681873.

# Before

```console
$ python setup.py --name
  File "setup.py", line 68
    project_urls: {
                ^
SyntaxError: invalid syntax
```

# After

```console
$ python setup.py --name
certifi
```