### PR TITLE
Add 2 basic unit tests

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -1,0 +1,40 @@
+# This workflow will install Python dependencies, run tests and lint with a variety of Python versions
+# For more information see: https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
+
+name: Python package
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [3.5, 3.6, 3.7, 3.8]
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install test dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install pytest
+    #    pip install flake8 pytest
+    #    if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+    #- name: Lint with flake8
+    #  run: |
+    #    # stop the build if there are Python syntax errors or undefined names
+    #   flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
+    #    # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
+    #    flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+    - name: Test with pytest
+      run: |
+        pytest

--- a/certifi/tests/__init__.py
+++ b/certifi/tests/__init__.py
@@ -1,0 +1,2 @@
+# certify.tests module
+

--- a/certifi/tests/test_certify.py
+++ b/certifi/tests/test_certify.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+"""
+unit tests to make sure everything behaves as expected
+"""
+
+import os
+import unittest
+
+import certifi
+
+
+class TestCertifi(unittest.TestCase):
+
+    def test_cabundle_exists(self):
+        """Check that the reported bundle exists"""
+        assert os.path.exists(certifi.where())
+
+    def test_read_contents(self):
+        content = certifi.contents()
+        assert "-----BEGIN CERTIFICATE-----" in content


### PR DESCRIPTION
Closes #136 

These tests are very basic. They just check that the returned string is really a file and contains the PEM certificate header.

The workflow runs with pytest, but you could also use native `python -m unittest`.

Further work could use openssl or the Python module [Cryptography](https://cryptography.io/en/latest/) to check for valid CA certificates.