### PR TITLE
Declare support for Python 3.9

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -63,7 +63,8 @@ setup(
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
-        'Programming Language :: Python :: 3.8'
+        'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
     ],
     project_urls: {
         'Documentation': 'https://certifiio.readthedocs.io/en/latest/',


### PR DESCRIPTION
Released on 2020-10-05:

* https://www.python.org/downloads/release/python-390/