### PR TITLE
Fix homepage link

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,7 +1,7 @@
 Certifi: Python SSL Certificates
 ================================
 
-`Certifi`_ provides Mozilla's carefully curated collection of Root Certificates for
+Certifi provides Mozilla's carefully curated collection of Root Certificates for
 validating the trustworthiness of SSL certificates while verifying the identity
 of TLS hosts. It has been extracted from the `Requests`_ project.
 
@@ -44,7 +44,6 @@ In previous versions, ``certifi`` provided the ``certifi.old_where()`` function
 to intentionally re-add the 1024-bit roots back into your bundle. This was not
 recommended in production and therefore was removed at the end of 2018.
 
-.. _`Certifi`: https://certifiio.readthedocs.io/en/latest/
 .. _`Requests`: https://requests.readthedocs.io/en/master/
 
 Addition/Removal of Certificates

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ setup(
     long_description=open('README.rst').read(),
     author='Kenneth Reitz',
     author_email='me@kennethreitz.com',
-    url='https://certifiio.readthedocs.io/en/latest/',
+    url='https://github.com/certifi/python-certifi',
     packages=[
         'certifi',
     ],
@@ -64,7 +64,6 @@ setup(
         'Programming Language :: Python :: 3.9',
     ],
     project_urls={
-        'Documentation': 'https://certifiio.readthedocs.io/en/latest/',
         'Source': 'https://github.com/certifi/python-certifi',
     },
 )


### PR DESCRIPTION
Fixes https://github.com/certifi/python-certifi/issues/132.

https://certifiio.readthedocs.io/en/latest/ redirects to https://certifi.io/en/latest/, which returns a 403 forbidden from Cloudflare.

Fix by using the repo page as the homepage, and removing the broken docs link. Can be reinstated if certifiio.readthedocs.io or certifi.io are brought back online.

Please also remove the `https://certifi.io/` URL from the About section of the homepage (it's not in code): https://github.com/certifi/python-certifi