### PR TITLE
docs: fix typo in LICENSE

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-This packge contains a modified version of ca-bundle.crt:
+This package contains a modified version of ca-bundle.crt:
 
 ca-bundle.crt -- Bundle of CA Root Certificates
 


### PR DESCRIPTION
Hello,

This tiny PR will fix : 

- 1 typo in `LICENSE`



Cheers! :robot: