### PR TITLE
Do not declare Python-3-only wheels as universal

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,0 @@
-[bdist_wheel]
-universal = 1


### PR DESCRIPTION
Only wheels that support both Python 2 and 3 are universal.  Support for Python 2 was dropped in commit 5efdd48f719d9c3c7c8f9a812da2256d088eab78 (part of release 2020.04.05.2).