### PR TITLE
License file to be included into metadata dir

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,5 @@
 [bdist_wheel]
 universal = 1
+
+[metadata]
+license_file = LICENSE


### PR DESCRIPTION
Hi,
please, add the LICENSE file into metadata dir of your package (e.g. by accepting this pull request).
Your certifi package does not ship the text of its license. Probably you want that.
By accepting this pull request you find the license file in e.g. .../site-packages/certifi-2021.5.30-py3.9.egg-info/LICENSE of your virtualenv after the certifi installation.

Thank you for your time.
Pax et bonum.