### PR TITLE
Remove Python 2 universal wheel from setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,2 @@
-[bdist_wheel]
-universal = 1
-
 [metadata]
 license_file = LICENSE


### PR DESCRIPTION
Now that the project doesn't support Python 2, the wheel should no
longer be marked universal.