### PR TITLE
Update python version in README: 3.7 -> 3.9

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -21,12 +21,12 @@ built-in function::
     >>> import certifi
 
     >>> certifi.where()
-    '/usr/local/lib/python3.7/site-packages/certifi/cacert.pem'
+    '/usr/local/lib/python3.9/site-packages/certifi/cacert.pem'
 
 Or from the command line::
 
     $ python -m certifi
-    /usr/local/lib/python3.7/site-packages/certifi/cacert.pem
+    /usr/local/lib/python3.9/site-packages/certifi/cacert.pem
 
 Enjoy!
 


### PR DESCRIPTION
In relation to 5efdd48 ("Goodbye python 2"), this commit updates python version in README to the latest.

Well, "python3.xx" would be possibly better, for Python 3.10 will be released soon?