### PR TITLE
Fix deprecation warning on Python 3.11

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,7 @@ jobs:
     strategy:
       matrix:
         python-version:
+        - "3.6"
         - "3.7"
         - "3.8"
         - "3.9"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,8 +22,12 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10"]
-
+        python-version:
+        - "3.7"
+        - "3.8"
+        - "3.9"
+        - "3.10"
+        - "3.11-dev"
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}
@@ -36,4 +40,4 @@ jobs:
         python -m pip install pytest
     - name: Test with pytest
       run: |
-        pytest
+        python -W error -m pytest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,9 +10,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
       - name: Install dependencies
         run: pip install mypy
       - name: Run mypy
@@ -30,9 +30,9 @@ jobs:
         - "3.10"
         - "3.11-dev"
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install test dependencies

--- a/certifi/core.py
+++ b/certifi/core.py
@@ -4,12 +4,12 @@ certifi.py
 
 This module returns the installation location of cacert.pem or its contents.
 """
-import os
-import types
-from typing import Union
+import sys
 
-try:
-    from importlib.resources import path as get_path, read_text
+
+if sys.version_info >= (3, 9):
+
+    from importlib.resources import as_file, files
 
     _CACERT_CTX = None
     _CACERT_PATH = None
@@ -33,36 +33,45 @@ try:
             # We also have to hold onto the actual context manager, because
             # it will do the cleanup whenever it gets garbage collected, so
             # we will also store that at the global level as well.
+            _CACERT_CTX = as_file(files("certifi").joinpath("cacert.pem"))
+            _CACERT_PATH = str(_CACERT_CTX.__enter__())
+
+        return _CACERT_PATH
+
+    def contents() -> str:
+        return files("certifi").joinpath("cacert.pem").read_text(encoding="ascii")
+
+else:
+
+    from importlib.resources import path as get_path, read_text
+
+    _CACERT_CTX = None
+    _CACERT_PATH = None
+
+    def where() -> str:
+        # This is slightly terrible, but we want to delay extracting the
+        # file in cases where we're inside of a zipimport situation until
+        # someone actually calls where(), but we don't want to re-extract
+        # the file on every call of where(), so we'll do it once then store
+        # it in a global variable.
+        global _CACERT_CTX
+        global _CACERT_PATH
+        if _CACERT_PATH is None:
+            # This is slightly janky, the importlib.resources API wants you
+            # to manage the cleanup of this file, so it doesn't actually
+            # return a path, it returns a context manager that will give
+            # you the path when you enter it and will do any cleanup when
+            # you leave it. In the common case of not needing a temporary
+            # file, it will just return the file system location and the
+            # __exit__() is a no-op.
+            #
+            # We also have to hold onto the actual context manager, because
+            # it will do the cleanup whenever it gets garbage collected, so
+            # we will also store that at the global level as well.
             _CACERT_CTX = get_path("certifi", "cacert.pem")
             _CACERT_PATH = str(_CACERT_CTX.__enter__())
 
         return _CACERT_PATH
 
-
-except ImportError:
-    Package = Union[types.ModuleType, str]
-    Resource = Union[str, "os.PathLike"]
-
-    # This fallback will work for Python versions prior to 3.7 that lack the
-    # importlib.resources module but relies on the existing `where` function
-    # so won't address issues with environments like PyOxidizer that don't set
-    # __file__ on modules.
-    def read_text(
-        package: Package,
-        resource: Resource,
-        encoding: str = 'utf-8',
-        errors: str = 'strict'
-    ) -> str:
-        with open(where(), encoding=encoding) as data:
-            return data.read()
-
-    # If we don't have importlib.resources, then we will just do the old logic
-    # of assuming we're on the filesystem and munge the path directly.
-    def where() -> str:
-        f = os.path.dirname(__file__)
-
-        return os.path.join(f, "cacert.pem")
-
-
-def contents() -> str:
-    return read_text("certifi", "cacert.pem", encoding="ascii")
+    def contents() -> str:
+        return read_text("certifi", "cacert.pem", encoding="ascii")

--- a/certifi/core.py
+++ b/certifi/core.py
@@ -41,7 +41,7 @@ if sys.version_info >= (3, 9):
     def contents() -> str:
         return files("certifi").joinpath("cacert.pem").read_text(encoding="ascii")
 
-else:
+elif sys.version_info >= (3, 7):
 
     from importlib.resources import path as get_path, read_text
 
@@ -75,3 +75,31 @@ else:
 
     def contents() -> str:
         return read_text("certifi", "cacert.pem", encoding="ascii")
+
+else:
+    import os
+    import types
+    from typing import Union
+
+    Package = Union[types.ModuleType, str]
+    Resource = Union[str, "os.PathLike"]
+
+    # This fallback will work for Python versions prior to 3.7 that lack the
+    # importlib.resources module but relies on the existing `where` function
+    # so won't address issues with environments like PyOxidizer that don't set
+    # __file__ on modules.
+    def read_text(
+        package: Package,
+        resource: Resource,
+        encoding: str = 'utf-8',
+        errors: str = 'strict'
+    ) -> str:
+        with open(where(), encoding=encoding) as data:
+            return data.read()
+
+    # If we don't have importlib.resources, then we will just do the old logic
+    # of assuming we're on the filesystem and munge the path directly.
+    def where() -> str:
+        f = os.path.dirname(__file__)
+
+        return os.path.join(f, "cacert.pem")

--- a/certifi/core.py
+++ b/certifi/core.py
@@ -103,3 +103,6 @@ else:
         f = os.path.dirname(__file__)
 
         return os.path.join(f, "cacert.pem")
+
+    def contents() -> str:
+        return read_text("certifi", "cacert.pem", encoding="ascii")

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ setup(
     include_package_data=True,
     zip_safe=False,
     license='MPL-2.0',
-    python_requires=">=3.6",
+    python_requires=">=3.7",
     classifiers=[
         'Development Status :: 5 - Production/Stable',
         'Intended Audience :: Developers',
@@ -54,11 +54,12 @@ setup(
         'Natural Language :: English',
         'Programming Language :: Python',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3 :: Only',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',
+        'Programming Language :: Python :: 3.11',
     ],
     project_urls={
         'Source': 'https://github.com/certifi/python-certifi',

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ setup(
     include_package_data=True,
     zip_safe=False,
     license='MPL-2.0',
-    python_requires=">=3.7",
+    python_requires=">=3.6",
     classifiers=[
         'Development Status :: 5 - Production/Stable',
         'Intended Audience :: Developers',
@@ -55,6 +55,7 @@ setup(
         'Programming Language :: Python',
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3 :: Only',
+        'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',


### PR DESCRIPTION
Fixes #192.

Replaces and closes https://github.com/certifi/python-certifi/pull/193.

This is @adamchainz' PR https://github.com/certifi/python-certifi/pull/193 with @AA-Turner's suggestions applied, plus adding a missing `where` for 3.6 which is the same as the 3.7-3.8 block.

Also bump GitHub Actions versions.