### PR TITLE
Only use importlib.resources's new files() / Traversable API on Python ≥3.11

### DIFF
--- a/certifi/core.py
+++ b/certifi/core.py
@@ -7,7 +7,7 @@ This module returns the installation location of cacert.pem or its contents.
 import sys
 
 
-if sys.version_info >= (3, 9):
+if sys.version_info >= (3, 11):
 
     from importlib.resources import as_file, files
 


### PR DESCRIPTION
Using importlib.resource's files() API on 3.9 and 3.10 causes a TypeError on 3.9 and a ValueError on 3.10 when running under a third-party meta path importer (like PyOxidizer's OxidizedImporter) that doesn't support the relatively-new API.  This is because the full adapter layer (importlib.resources.\_adapters) for the older importlib resources API doesn't exist until Python 3.11.

The older resources API is now used by 3.7–3.10, as it was prior to the certifi 2022.06.15.1 release.  This codepath has existed in certifi since April 2020 (3fc8fec).

An alternative to this change would be testing the actual importer in use at runtime (e.g. certifi.\_\_loader\_\_) for files() support, but that seemed more complex than reverting to the previous codepath here.

Resolves: https://github.com/certifi/python-certifi/issues/203
Related-to: https://github.com/certifi/python-certifi/pull/199
Related-to: https://github.com/certifi/python-certifi/pull/123