### PR TITLE
Set up permissions to github workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches: [master]
   pull_request: {}
+  
+permissions:
+  contents: read
 
 jobs:
   mypy:

--- a/.github/workflows/lock.yml
+++ b/.github/workflows/lock.yml
@@ -4,13 +4,14 @@ on:
   schedule:
     - cron: '0 0 * * *'
 
-permissions:
-  issues: "write"
+permissions: {}
 
 jobs:
   lock:
     if: github.repository_owner == 'certifi'
     runs-on: ubuntu-latest
+    permissions:
+      issues: write
     steps:
       - uses: dessant/lock-threads@v3
         with:


### PR DESCRIPTION
### Changes

- set top level permission as `contents: read` to ci.yml. It seems to work with only a warn regarding python3.6 not giving support to attr: https://github.com/joycebrum/python-certifi/actions/runs/4256060098
- grant `issues: write` only to the job with no permissions in top-level. No permission has actually changed (it was only `issues: write` by the start) but any other job added to the workflow will have no permission by default. I can change it to `contents: read` if you rather.