### PR TITLE
Create a Security Policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,11 @@
+# Reporting Security Issues
+
+To report a security issue, please email
+[example@email.com](mailto:example@email.com)
+with a description of the issue, the steps you took to create the issue,
+affected versions, and, if known, mitigations for the issue.
+
+We will respond within 7 working days of your
+email. If the issue is confirmed as a vulnerability, we will open a
+Security Advisory and acknowledge your contributions as part of it. This project
+follows a 90 day disclosure timeline.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,11 +1,6 @@
 # Reporting Security Issues
 
-To report a security issue, please email [alex.gaynor@gmail.com](mailto:alex.gaynor@gmail.com) or
-[lukasaoz@gmail.com](mailto:lukasaoz@gmail.com)
-with a description of the issue, the steps you took to create the issue,
-affected versions, and, if known, mitigations for the issue.
+To report a security issue, please disclose it at [security advisory](https://github.com/certifi/python-certifi/security/advisories/new).
 
-We will respond within 7 working days of your
-email. If the issue is confirmed as a vulnerability, we will open a
-Security Advisory and acknowledge your contributions as part of it. This project
-follows a 90 day disclosure timeline.
+We will respond within 7 working days of your submission. If the issue is confirmed as a vulnerability, we will open a Security Advisory and acknowledge your contributions as part of it. This project follows a 90 day disclosure timeline.
+

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,7 +1,7 @@
 # Reporting Security Issues
 
-To report a security issue, please email
-[example@email.com](mailto:example@email.com)
+To report a security issue, please email [alex.gaynor@gmail.com](mailto:alex.gaynor@gmail.com) or
+[lukasaoz@gmail.com](mailto:lukasaoz@gmail.com)
 with a description of the issue, the steps you took to create the issue,
 affected versions, and, if known, mitigations for the issue.
 


### PR DESCRIPTION
### Changes

Closes #221 

- Create the security.md file with a standard body

It needs yet a security email to gather possible vulnerabilities reports.

I've proposed this [vulnerability disclosure](https://www.techtarget.com/searchsecurity/definition/vulnerability-disclosure) timeline but let me know if you are more confortable with a different one. 

PS: the  Security Advisory is a github tool to Vulnerabilities Disclosures (I've seen you've already familiar with it).

Besides that feel free to edit or suggest any changes to this document, it is supposed to reflect the amount of effort the team can offer to handle vulnerabilities.  