### PR TITLE
workflows: add trusted publishing release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,6 +16,9 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@61a6322f88396a6271a6ee3565807d608ecaddd1 # v4.7.0
 
+      - name: Install build dependencies
+        run: python -m pip install --upgrade setuptools wheel
+
       - name: Build distributions
         run: python setup.py sdist bdist_wheel
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,48 @@
+on:
+  push:
+    tags:
+      - "v*.*.*"
+
+name: release
+
+jobs:
+  build:
+    name: Build distributions for PyPI
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
+
+      - name: Set up Python
+        uses: actions/setup-python@61a6322f88396a6271a6ee3565807d608ecaddd1 # v4.7.0
+
+      - name: Build distributions
+        run: python setup.py sdist bdist_wheel
+
+      - name: Upload distributions
+        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
+        with:
+          name: certifi-dists
+          path: dist/
+
+  pypi:
+    name: Publish to PyPI
+    runs-on: ubuntu-latest
+    environment: release
+
+    needs:
+      - build
+
+    permissions:
+      # Used to authenticate to PyPI via OIDC.
+      id-token: write
+
+    steps:
+      - name: fetch dists
+        uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
+        with:
+          name: certifi-dists
+          path: dist/
+
+      - name: publish
+        uses: pypa/gh-action-pypi-publish@f8c70e705ffc13c3b4d1221169b84f12a75d6ca8 # v1.8.8

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
         uses: actions/setup-python@61a6322f88396a6271a6ee3565807d608ecaddd1 # v4.7.0
 
       - name: Install build dependencies
-        run: python -m pip install --upgrade setuptools wheel build
+        run: python -m pip install setuptools wheel build
 
       - name: Build distributions
         run: python -m build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,10 +18,10 @@ jobs:
         uses: actions/setup-python@61a6322f88396a6271a6ee3565807d608ecaddd1 # v4.7.0
 
       - name: Install build dependencies
-        run: python -m pip install --upgrade setuptools wheel
+        run: python -m pip install --upgrade setuptools wheel build
 
       - name: Build distributions
-        run: python setup.py sdist bdist_wheel
+        run: python -m build
 
       - name: Upload distributions
         uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,5 @@
 on:
+  workflow_dispatch:
   push:
     tags:
       - "*.*.*"
@@ -48,4 +49,5 @@ jobs:
           path: dist/
 
       - name: publish
+        if: github.event_name == 'push'
         uses: pypa/gh-action-pypi-publish@f8c70e705ffc13c3b4d1221169b84f12a75d6ca8 # v1.8.8

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
         uses: actions/setup-python@61a6322f88396a6271a6ee3565807d608ecaddd1 # v4.7.0
 
       - name: Install build dependencies
-        run: python -m pip install setuptools wheel build
+        run: python -m pip install build
 
       - name: Build distributions
         run: python -m build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,7 +1,7 @@
 on:
   push:
     tags:
-      - "v*.*.*"
+      - "*.*.*"
 
 name: release
 

--- a/Makefile
+++ b/Makefile
@@ -2,5 +2,5 @@ update:
 	curl https://mkcert.org/generate/ | ./strip-non-ascii > certifi/cacert.pem
 
 publish:
-	python setup.py sdist bdist_wheel
+	python -m build
 	twine upload --skip-existing --sign dist/*

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,5 @@
 #!/usr/bin/env python
 import re
-import os
-import sys
 
 # While I generally consider it an antipattern to try and support both
 # setuptools and distutils with a single setup.py, in this specific instance
@@ -16,7 +14,7 @@ except ImportError:
 
 
 version_regex = r'__version__ = ["\']([^"\']*)["\']'
-with open('certifi/__init__.py') as f:
+with open("certifi/__init__.py") as f:
     text = f.read()
     match = re.search(version_regex, text)
 
@@ -25,44 +23,40 @@ with open('certifi/__init__.py') as f:
     else:
         raise RuntimeError("No version number found!")
 
-if sys.argv[-1] == 'publish':
-    os.system('python setup.py sdist bdist_wheel upload')
-    sys.exit()
-
 setup(
-    name='certifi',
+    name="certifi",
     version=VERSION,
-    description='Python package for providing Mozilla\'s CA Bundle.',
-    long_description=open('README.rst').read(),
-    author='Kenneth Reitz',
-    author_email='me@kennethreitz.com',
-    url='https://github.com/certifi/python-certifi',
+    description="Python package for providing Mozilla's CA Bundle.",
+    long_description=open("README.rst").read(),
+    author="Kenneth Reitz",
+    author_email="me@kennethreitz.com",
+    url="https://github.com/certifi/python-certifi",
     packages=[
-        'certifi',
+        "certifi",
     ],
-    package_dir={'certifi': 'certifi'},
-    package_data={'certifi': ['*.pem', 'py.typed']},
+    package_dir={"certifi": "certifi"},
+    package_data={"certifi": ["*.pem", "py.typed"]},
     # data_files=[('certifi', ['certifi/cacert.pem'])],
     include_package_data=True,
     zip_safe=False,
-    license='MPL-2.0',
+    license="MPL-2.0",
     python_requires=">=3.6",
     classifiers=[
-        'Development Status :: 5 - Production/Stable',
-        'Intended Audience :: Developers',
-        'License :: OSI Approved :: Mozilla Public License 2.0 (MPL 2.0)',
-        'Natural Language :: English',
-        'Programming Language :: Python',
-        'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3 :: Only',
-        'Programming Language :: Python :: 3.6',
-        'Programming Language :: Python :: 3.7',
-        'Programming Language :: Python :: 3.8',
-        'Programming Language :: Python :: 3.9',
-        'Programming Language :: Python :: 3.10',
-        'Programming Language :: Python :: 3.11',
+        "Development Status :: 5 - Production/Stable",
+        "Intended Audience :: Developers",
+        "License :: OSI Approved :: Mozilla Public License 2.0 (MPL 2.0)",
+        "Natural Language :: English",
+        "Programming Language :: Python",
+        "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3 :: Only",
+        "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
     ],
     project_urls={
-        'Source': 'https://github.com/certifi/python-certifi',
+        "Source": "https://github.com/certifi/python-certifi",
     },
 )


### PR DESCRIPTION
This adds `release.yml`, which uses PyPI's trusted publishing functionality to publish releases of `certifi` to PyPI without needing a pre-shared API token.

This needs a few manual considerations before it can be merged:

* The tag pattern is currently specified as `v*.*.*`, whereas the current release tag pattern is just `*.*.*`. My *recommendation* would be to move future releases onto the `v*.*.*` pattern, but it's not a blocker for using trusted publishing and I can change the pattern to just `*.*.*` if you'd prefer.
* The new release workflow currently specifies a `release` environment, which I recommend you configure (both on GitHub *and* on PyPI, when registering the trusted publisher). My recommendation is that this environment include a [deployment protection rule](https://docs.github.com/en/actions/deployment/targeting-different-environments/using-environments-for-deployment#deployment-protection-rules) that requires manual approval from a `certifi` maintainer, meaning that even an attacker who compromises the repository will be unable to force a PyPI publish.
* Separately, I recommend setting up a [tag protection rule](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-tag-protection-rules) for the `v*.*.*` pattern, if you end up going with that. That protection rule is only applicable if you include the `v` prefix, since tag protection rules use `fnmatch(3)` syntax.
* Finally, this needs a corresponding trusted publisher registration on PyPI! It should be something like:

    ```
    Repository Owner: certifi
    Repository Name: python-certifi
    Workflow Name: release.yml
    Environment Name: release
    ```