### PR TITLE
fix leaking certificate issue

### DIFF
--- a/certifi/core.py
+++ b/certifi/core.py
@@ -5,6 +5,10 @@ certifi.py
 This module returns the installation location of cacert.pem or its contents.
 """
 import sys
+import atexit
+
+def exit_cacert_ctx() -> None:
+    _CACERT_CTX.__exit__(None, None, None)
 
 
 if sys.version_info >= (3, 11):
@@ -35,6 +39,7 @@ if sys.version_info >= (3, 11):
             # we will also store that at the global level as well.
             _CACERT_CTX = as_file(files("certifi").joinpath("cacert.pem"))
             _CACERT_PATH = str(_CACERT_CTX.__enter__())
+            atexit.register(exit_cacert_ctx)
 
         return _CACERT_PATH
 
@@ -70,6 +75,7 @@ elif sys.version_info >= (3, 7):
             # we will also store that at the global level as well.
             _CACERT_CTX = get_path("certifi", "cacert.pem")
             _CACERT_PATH = str(_CACERT_CTX.__enter__())
+            atexit.register(exit_cacert_ctx)
 
         return _CACERT_PATH
 

--- a/certifi/core.py
+++ b/certifi/core.py
@@ -8,7 +8,7 @@ import sys
 import atexit
 
 def exit_cacert_ctx() -> None:
-    _CACERT_CTX.__exit__(None, None, None)
+    _CACERT_CTX.__exit__(None, None, None)  # type: ignore[attr-defined]
 
 
 if sys.version_info >= (3, 11):

--- a/certifi/core.py
+++ b/certifi/core.py
@@ -8,7 +8,7 @@ import sys
 import atexit
 
 def exit_cacert_ctx() -> None:
-    _CACERT_CTX.__exit__(None, None, None)  # type: ignore[attr-defined]
+    _CACERT_CTX.__exit__(None, None, None)  # type: ignore[union-attr]
 
 
 if sys.version_info >= (3, 11):


### PR DESCRIPTION
we've had an issue with leaking files on `/tmp` from certifi

This PR is explicitly calling `.__exit__` as it seems like its not a no-op on all cases