### PR TITLE
Declare setuptools as the build backend in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools >= 42.0.0"]
+build-backend = "setuptools.build_meta"


### PR DESCRIPTION
Otherwise, pip 25.1 issues a deprecation warning about `setup.py bdist_wheel` from installing from source, xref https://github.com/pypa/pip/issues/6334.

OTOH, certifi installs from source just fine without an explicit build-system declaration. When setuptools is not installed, pip will use a default pyproject.toml and install setuptools in a temporary environment.