### PR TITLE
Add GitHub issue template to redirect certificate addition requests

### DIFF
--- a/.github/ISSUE_TEMPLATE/certificate_issue.md
+++ b/.github/ISSUE_TEMPLATE/certificate_issue.md
@@ -1,0 +1,19 @@
+---
+name: Bug Report or Feature Request
+about: Report a bug or suggest a feature for certifi
+title: ''
+labels: ''
+assignees: ''
+---
+
+**Important:** Certifi is a repackaging of the [Mozilla CA Certificate Program](https://wiki.mozilla.org/CA) root certificates. It does not add, remove, or modify certificates. If you are looking to:
+
+- **Add a custom or organizational certificate**: See the [Requests documentation on SSL certificates](https://requests.readthedocs.io/en/latest/user/advanced/#ssl-cert-verification) or set the `REQUESTS_CA_BUNDLE` environment variable to point to your custom bundle.
+- **Fix a missing intermediate certificate error**: This is typically a server-side configuration issue. See [this StackOverflow answer](https://stackoverflow.com/a/66111417) for guidance.
+- **Add a certificate to the Mozilla bundle**: File a bug with [Mozilla's CA Certificate Program](https://bugzilla.mozilla.org/enter_bug.cgi?product=CA%20Certificates&component=CA%20Certificate%20Root%20Program).
+- **Report a missing/revoked root certificate**: File a bug with [Mozilla](https://bugzilla.mozilla.org/enter_bug.cgi?product=CA%20Certificates&component=CA%20Certificate%20Root%20Program) since certifi tracks their bundle.
+
+---
+
+**Description**
+<!-- A clear description of your bug report or feature request. -->

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Add or remove a certificate
+    url: https://github.com/certifi/python-certifi#additionremoval-of-certificates
+    about: Certifi tracks Mozilla's bundle and does not modify it. See the README for guidance.
+  - name: Report a certificate to Mozilla
+    url: https://bugzilla.mozilla.org/enter_bug.cgi?product=CA%20Certificates&component=CA%20Certificate%20Root%20Program
+    about: If a root certificate should be added or removed, report it directly to Mozilla's CA Certificate Program.


### PR DESCRIPTION
Certifi tracks Mozilla's CA Certificate Program and does not modify certificates. This PR adds an issue template to help users find the right place for certificate-related requests and provides guidance for common SSL issues.

### What's included
- **Issue template** (): A markdown template that prominently explains certifi's scope and redirects users to the appropriate resources (Mozilla Bugzilla, Requests docs, StackOverflow).
- **Template config** (): Disables blank issues and adds contact links pointing to the README and Mozilla's Bugzilla.

### Addresses
Closes #72

This should significantly reduce the number of 'please add this certificate' issues by guiding users to the correct upstream project.