### PR TITLE
Include tests in the source distribution

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,6 @@
 include MANIFEST.in README.rst LICENSE certifi/cacert.pem certifi/py.typed
+recursive-include certifi/tests *
 
 exclude .github/
 recursive-exclude .github
+global-exclude *.py[cod] __pycache__ .DS_Store


### PR DESCRIPTION
## Summary

`certifi/tests` already lives in the repository, but `MANIFEST.in` only listed package data files (`cacert.pem`, `py.typed`, etc.). Source distributions therefore shipped without the test suite, which makes downstream sdist testing harder (#226).

## Changes

- Add `recursive-include certifi/tests *` so the suite is packaged in the sdist.
- Add `global-exclude *.py[cod] __pycache__ .DS_Store` so local bytecode is not pulled into the archive when tests are included.

## Test plan

- `python3 setup.py sdist` — archive lists `certifi/tests/__init__.py` and `certifi/tests/test_certify.py`, no `__pycache__`.
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python3 -W error -m pytest -q` from git tree: 3 passed.
- Same pytest command from the extracted sdist root: 3 passed.
- `python3 -m unittest discover -s certifi/tests -v` from extracted sdist: 3 OK.

Closes #226
